### PR TITLE
Better receiver names.

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,6 @@ func WithConfigChanges(mods ...ConfigModifier) SeedModifier {
 	}
 }
 
-func (l *Log) Config() Config {
-	return l.span.seed.config
+func (log *Log) Config() Config {
+	return log.span.seed.config
 }

--- a/context.go
+++ b/context.go
@@ -11,8 +11,8 @@ var contextKey = contextKeyType{}
 // TODO: have a default log that prints
 var Default = NewSeed().Request("discard")
 
-func (l *Log) IntoContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, contextKey, l)
+func (log *Log) IntoContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKey, log)
 }
 
 func FromContext(ctx context.Context) (*Log, bool) {

--- a/rest/request.go
+++ b/rest/request.go
@@ -46,7 +46,7 @@ func Log(log xop.Log) *rest.RequestOpts {
 			return nil
 		}).
 		DoAfter(func(result rest.Result) rest.Result {
-			var line *xop.LogLine
+			var line *xop.Line
 			if result.Error != nil {
 				line = step.Error()
 			} else {

--- a/seed.go
+++ b/seed.go
@@ -45,20 +45,20 @@ func NewSeed(mods ...SeedModifier) Seed {
 
 // Seed provides a copy of the current span's seed, but the
 // spanID is randomized.
-func (s *Span) Seed(mods ...SeedModifier) Seed {
+func (span *Span) Seed(mods ...SeedModifier) Seed {
 	seed := Seed{
-		spanSeed: s.seed.Copy(),
-		settings: s.log.settings.Copy(),
+		spanSeed: span.seed.Copy(),
+		settings: span.log.settings.Copy(),
 	}
 	seed.spanSeed.traceBundle.Trace.RandomizeSpanID()
 	return seed.applyMods(mods)
 }
 
-func (s Seed) applyMods(mods []SeedModifier) Seed {
+func (seed Seed) applyMods(mods []SeedModifier) Seed {
 	for _, mod := range mods {
-		mod(&s)
+		mod(&seed)
 	}
-	return s
+	return seed
 }
 
 func WithBundle(bundle trace.Bundle) SeedModifier {
@@ -79,12 +79,12 @@ func WithSettings(f func(*LogSettings)) SeedModifier {
 	}
 }
 
-func (s Seed) Trace() trace.Bundle {
-	return s.traceBundle
+func (seed Seed) Trace() trace.Bundle {
+	return seed.traceBundle
 }
 
-func (s Seed) SubSpan() Seed {
-	s.traceBundle = s.traceBundle.Copy()
-	s.traceBundle.Trace.RandomizeSpanID()
-	return s
+func (seed Seed) SubSpan() Seed {
+	seed.traceBundle = seed.traceBundle.Copy()
+	seed.traceBundle.Trace.RandomizeSpanID()
+	return seed
 }

--- a/seed.zzzgo
+++ b/seed.zzzgo
@@ -43,20 +43,20 @@ func NewSeed(mods ...SeedModifier) Seed {
 
 // Seed provides a copy of the current span's seed, but the
 // spanID is randomized.
-func (s *Span) Seed(mods ...SeedModifier) Seed {
+func (span *Span) Seed(mods ...SeedModifier) Seed {
 	seed := Seed{
-		spanSeed: s.seed.Copy(),
-		settings: s.log.settings.Copy(),
+		spanSeed: span.seed.Copy(),
+		settings: span.log.settings.Copy(),
 	}
 	seed.spanSeed.traceBundle.Trace.RandomizeSpanID()
 	return seed.applyMods(mods)
 }
 
-func (s Seed) applyMods(mods []SeedModifier) Seed {
+func (seed Seed) applyMods(mods []SeedModifier) Seed {
 	for _, mod := range mods {
-		mod(&s)
+		mod(&seed)
 	}
-	return s
+	return seed
 }
 
 func WithBundle(bundle trace.Bundle) SeedModifier {
@@ -77,12 +77,12 @@ func WithSettings(f func(*LogSettings)) SeedModifier {
 	}
 }
 
-func (s Seed) Trace() trace.Bundle {
-	return s.traceBundle
+func (seed Seed) Trace() trace.Bundle {
+	return seed.traceBundle
 }
 
-func (s Seed) SubSpan() Seed {
-	s.traceBundle = s.traceBundle.Copy()
-	s.traceBundle.Trace.RandomizeSpanID()
-	return s
+func (seed Seed) SubSpan() Seed {
+	seed.traceBundle = seed.traceBundle.Copy()
+	seed.traceBundle.Trace.RandomizeSpanID()
+	return seed
 }

--- a/span.go
+++ b/span.go
@@ -13,32 +13,32 @@ import (
 
 // Request provides access to the span that describes the overall
 // request. Metadata may be added at the request level.
-func (l *Log) Request() *Span {
-	return l.request
+func (log *Log) Request() *Span {
+	return log.request
 }
 
 // Request provides access to the current span
 // Metadata may be added at the span level.
-func (l *Log) Span() *Span {
-	return l.span
+func (log *Log) Span() *Span {
+	return log.span
 }
 
-func (s *Span) TraceState() trace.State     { return s.seed.traceBundle.State }
-func (s *Span) TraceBaggage() trace.Baggage { return s.seed.traceBundle.Baggage }
-func (s *Span) TraceParent() trace.Trace    { return s.seed.traceBundle.TraceParent.Copy() }
-func (s *Span) Trace() trace.Trace          { return s.seed.traceBundle.Trace.Copy() }
-func (s *Span) Bundle() trace.Bundle        { return s.seed.traceBundle.Copy() }
+func (span *Span) TraceState() trace.State     { return span.seed.traceBundle.State }
+func (span *Span) TraceBaggage() trace.Baggage { return span.seed.traceBundle.Baggage }
+func (span *Span) TraceParent() trace.Trace    { return span.seed.traceBundle.TraceParent.Copy() }
+func (span *Span) Trace() trace.Trace          { return span.seed.traceBundle.Trace.Copy() }
+func (span *Span) Bundle() trace.Bundle        { return span.seed.traceBundle.Copy() }
 
-func (s *Span) eft() *Span {
-	s.log.enableFlushTimer()
-	return s
+func (span *Span) eft() *Span {
+	span.log.enableFlushTimer()
+	return span
 }
 
 // Int64 adds a int64 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
-	s.base.MetadataInt64(k, v)
-	return s.eft()
+func (span *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
+	span.base.MetadataInt64(k, v)
+	return span.eft()
 }
 
 // EmbeddedEnum adds a kev/value attribute to the Span.  The key and the value
@@ -47,8 +47,8 @@ func (s *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
 // to add enum key/value pairs where the key and value are specified
 // separately.
 // The return value does not need to be used.
-func (s *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
-	return s.Enum(kv.EnumAttribute(), kv)
+func (span *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
+	return span.Enum(kv.EnumAttribute(), kv)
 }
 
 // AnyImmutable adds a key/value attribute to the current Span.  The provided
@@ -60,9 +60,9 @@ func (s *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
 // for the type of the value, that type may or may not be checked depending
 // on the base logger being used.
 // The return value does not need to be used.
-func (s *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
-	s.base.MetadataAny(k, v)
-	return s.eft()
+func (span *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
+	span.base.MetadataAny(k, v)
+	return span.eft()
 }
 
 // Any adds a key/value attribute to the current Span.  The provided
@@ -72,88 +72,88 @@ func (s *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
 // for the type of the value, that type may or may not be checked depending
 // on the base logger being used.
 // The return value does not need to be used.
-func (s *Span) Any(k *xopconst.AnyAttribute, v interface{}) *Span {
-	if s.log.span.span.referencesKept {
+func (span *Span) Any(k *xopconst.AnyAttribute, v interface{}) *Span {
+	if span.log.span.span.referencesKept {
 		v = deepcopy.Copy(v)
 	}
-	s.base.MetadataAny(k, v)
-	return s.eft()
+	span.base.MetadataAny(k, v)
+	return span.eft()
 }
 
 // Bool adds a bool key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Bool(k *xopconst.BoolAttribute, v bool) *Span {
-	s.base.MetadataBool(k, v)
-	return s.eft()
+func (span *Span) Bool(k *xopconst.BoolAttribute, v bool) *Span {
+	span.base.MetadataBool(k, v)
+	return span.eft()
 }
 
 // Enum adds a xopconst.Enum key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Enum(k *xopconst.EnumAttribute, v xopconst.Enum) *Span {
-	s.base.MetadataEnum(k, v)
-	return s.eft()
+func (span *Span) Enum(k *xopconst.EnumAttribute, v xopconst.Enum) *Span {
+	span.base.MetadataEnum(k, v)
+	return span.eft()
 }
 
 // Float64 adds a float64 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Float64(k *xopconst.Float64Attribute, v float64) *Span {
-	s.base.MetadataFloat64(k, v)
-	return s.eft()
+func (span *Span) Float64(k *xopconst.Float64Attribute, v float64) *Span {
+	span.base.MetadataFloat64(k, v)
+	return span.eft()
 }
 
 // Link adds a trace.Trace key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Link(k *xopconst.LinkAttribute, v trace.Trace) *Span {
-	s.base.MetadataLink(k, v)
-	return s.eft()
+func (span *Span) Link(k *xopconst.LinkAttribute, v trace.Trace) *Span {
+	span.base.MetadataLink(k, v)
+	return span.eft()
 }
 
 // String adds a string key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) String(k *xopconst.StringAttribute, v string) *Span {
-	s.base.MetadataString(k, v)
-	return s.eft()
+func (span *Span) String(k *xopconst.StringAttribute, v string) *Span {
+	span.base.MetadataString(k, v)
+	return span.eft()
 }
 
 // Time adds a time.Time key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Time(k *xopconst.TimeAttribute, v time.Time) *Span {
-	s.base.MetadataTime(k, v)
-	return s.eft()
+func (span *Span) Time(k *xopconst.TimeAttribute, v time.Time) *Span {
+	span.base.MetadataTime(k, v)
+	return span.eft()
 }
 
 // should skip Int64
 // Duration adds a time.Duration key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Duration(k *xopconst.DurationAttribute, v time.Duration) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) Duration(k *xopconst.DurationAttribute, v time.Duration) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }
 
 // Int adds a int key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int(k *xopconst.IntAttribute, v int) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) Int(k *xopconst.IntAttribute, v int) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }
 
 // Int16 adds a int16 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int16(k *xopconst.Int16Attribute, v int16) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) Int16(k *xopconst.Int16Attribute, v int16) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }
 
 // Int32 adds a int32 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int32(k *xopconst.Int32Attribute, v int32) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) Int32(k *xopconst.Int32Attribute, v int32) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }
 
 // Int8 adds a int8 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int8(k *xopconst.Int8Attribute, v int8) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) Int8(k *xopconst.Int8Attribute, v int8) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }

--- a/span.zzzgo
+++ b/span.zzzgo
@@ -9,32 +9,32 @@ import (
 
 // Request provides access to the span that describes the overall
 // request. Metadata may be added at the request level.
-func (l *Log) Request() *Span {
-	return l.request
+func (log *Log) Request() *Span {
+	return log.request
 }
 
 // Request provides access to the current span
 // Metadata may be added at the span level.
-func (l *Log) Span() *Span {
-	return l.span
+func (log *Log) Span() *Span {
+	return log.span
 }
 
-func (s *Span) TraceState() trace.State     { return s.seed.traceBundle.State }
-func (s *Span) TraceBaggage() trace.Baggage { return s.seed.traceBundle.Baggage }
-func (s *Span) TraceParent() trace.Trace    { return s.seed.traceBundle.TraceParent.Copy() }
-func (s *Span) Trace() trace.Trace          { return s.seed.traceBundle.Trace.Copy() }
-func (s *Span) Bundle() trace.Bundle        { return s.seed.traceBundle.Copy() }
+func (span *Span) TraceState() trace.State     { return span.seed.traceBundle.State }
+func (span *Span) TraceBaggage() trace.Baggage { return span.seed.traceBundle.Baggage }
+func (span *Span) TraceParent() trace.Trace    { return span.seed.traceBundle.TraceParent.Copy() }
+func (span *Span) Trace() trace.Trace          { return span.seed.traceBundle.Trace.Copy() }
+func (span *Span) Bundle() trace.Bundle        { return span.seed.traceBundle.Copy() }
 
-func (s *Span) eft() *Span {
-	s.log.enableFlushTimer()
-	return s
+func (span *Span) eft() *Span {
+	span.log.enableFlushTimer()
+	return span
 }
 
 // Int64 adds a int64 key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
-	s.base.MetadataInt64(k, v)
-	return s.eft()
+func (span *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
+	span.base.MetadataInt64(k, v)
+	return span.eft()
 }
 
 // EmbeddedEnum adds a kev/value attribute to the Span.  The key and the value
@@ -43,8 +43,8 @@ func (s *Span) Int64(k *xopconst.Int64Attribute, v int64) *Span {
 // to add enum key/value pairs where the key and value are specified
 // separately.
 // The return value does not need to be used.
-func (s *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
-	return s.Enum(kv.EnumAttribute(), kv)
+func (span *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
+	return span.Enum(kv.EnumAttribute(), kv)
 }
 
 // AnyImmutable adds a key/value attribute to the current Span.  The provided
@@ -56,9 +56,9 @@ func (s *Span) EmbeddedEnum(kv xopconst.EmbeddedEnum) *Span {
 // for the type of the value, that type may or may not be checked depending
 // on the base logger being used.
 // The return value does not need to be used.
-func (s *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
-	s.base.MetadataAny(k, v)
-	return s.eft()
+func (span *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
+	span.base.MetadataAny(k, v)
+	return span.eft()
 }
 
 // Any adds a key/value attribute to the current Span.  The provided
@@ -68,27 +68,27 @@ func (s *Span) AnyImmutable(k *xopconst.AnyAttribute, v interface{}) *Span {
 // for the type of the value, that type may or may not be checked depending
 // on the base logger being used.
 // The return value does not need to be used.
-func (s *Span) Any(k *xopconst.AnyAttribute, v interface{}) *Span {
-	if s.log.span.span.referencesKept {
+func (span *Span) Any(k *xopconst.AnyAttribute, v interface{}) *Span {
+	if span.log.span.span.referencesKept {
 		v = deepcopy.Copy(v)
 	}
-	s.base.MetadataAny(k, v)
-	return s.eft()
+	span.base.MetadataAny(k, v)
+	return span.eft()
 }
 
 //MACRO BaseAttribute SKIP:Any,Int64
 // ZZZ adds a zzz key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) ZZZ(k *xopconst.ZZZAttribute, v zzz) *Span {
-	s.base.MetadataZZZ(k, v)
-	return s.eft()
+func (span *Span) ZZZ(k *xopconst.ZZZAttribute, v zzz) *Span {
+	span.base.MetadataZZZ(k, v)
+	return span.eft()
 }
 
 // should skip Int64
 // MACRO IntsPlus SKIP:Int64
 // ZZZ adds a zzz key/value attribute to the current Span.
 // The return value does not need to be used.
-func (s *Span) ZZZ(k *xopconst.ZZZAttribute, v zzz) *Span {
-	s.base.MetadataInt64(&k.Int64Attribute, int64(v))
-	return s.eft()
+func (span *Span) ZZZ(k *xopconst.ZZZAttribute, v zzz) *Span {
+	span.base.MetadataInt64(&k.Int64Attribute, int64(v))
+	return span.eft()
 }

--- a/sub.go
+++ b/sub.go
@@ -46,29 +46,29 @@ func (settings LogSettings) Copy() LogSettings {
 	return settings
 }
 
-func (l *Log) Settings() LogSettings {
-	return l.settings.Copy()
+func (log *Log) Settings() LogSettings {
+	return log.settings.Copy()
 }
 
 // Sub is the first step in creating a sub-Log from the current log.
 // Sub allows log settings to be modified.  The returned value must
 // be used.  It is used by a call to sub.Log(), sub.Fork(), or
 // sub.Step().
-func (l *Log) Sub() *Sub {
+func (log *Log) Sub() *Sub {
 	return &Sub{
-		settings: l.settings.Copy(),
-		log:      l,
+		settings: log.settings.Copy(),
+		log:      log,
 	}
 }
 
 // Fork creates a new Log that does not need to be terminated because
 // it is assumed to be done with the current log is finished.  The new log
 // has its own span.
-func (s *Sub) Fork(msg string, mods ...SeedModifier) *Log {
-	seed := s.log.span.Seed(mods...).SubSpan()
-	counter := int(atomic.AddInt32(&s.log.span.forkCounter, 1))
+func (sub *Sub) Fork(msg string, mods ...SeedModifier) *Log {
+	seed := sub.log.span.Seed(mods...).SubSpan()
+	counter := int(atomic.AddInt32(&sub.log.span.forkCounter, 1))
 	seed.spanSequenceCode += "." + base26(counter-1)
-	return s.log.newChildLog(seed.spanSeed, msg, s.settings)
+	return sub.log.newChildLog(seed.spanSeed, msg, sub.settings)
 }
 
 // Step creates a new log that does not need to be terminated -- it
@@ -76,20 +76,20 @@ func (s *Sub) Fork(msg string, mods ...SeedModifier) *Log {
 // something that is different and should be in a fresh span. The expectation
 // is that there is a parent log that is creating various sub-logs using
 // Step over and over as it does different things.
-func (s *Sub) Step(msg string, mods ...SeedModifier) *Log {
-	seed := s.log.span.Seed(mods...).SubSpan()
-	counter := int(atomic.AddInt32(&s.log.span.stepCounter, 1))
+func (sub *Sub) Step(msg string, mods ...SeedModifier) *Log {
+	seed := sub.log.span.Seed(mods...).SubSpan()
+	counter := int(atomic.AddInt32(&sub.log.span.stepCounter, 1))
 	seed.spanSequenceCode += "." + strconv.Itoa(counter)
-	return s.log.newChildLog(seed.spanSeed, msg, s.settings)
+	return sub.log.newChildLog(seed.spanSeed, msg, sub.settings)
 }
 
 // StackFrames sets the number of stack frames to include at
 // a logging level.  Levels above the given level will be set to
 // get least this many.  Levels below the given level will be set
 // to receive at most this many.
-func (s *Sub) StackFrames(level xopconst.Level, count int) *Sub {
-	s.settings.StackFrames(level, count)
-	return s
+func (sub *Sub) StackFrames(level xopconst.Level, count int) *Sub {
+	sub.settings.StackFrames(level, count)
+	return sub
 }
 
 // StackFrames sets the number of stack frames to include at
@@ -110,9 +110,9 @@ func (s *LogSettings) StackFrames(level xopconst.Level, frameCount int) {
 
 // MinLevel sets the minimum logging level below which logs will
 // be discarded.  The default is that no logs are discarded.
-func (s *Sub) MinLevel(level xopconst.Level) *Sub {
-	s.settings.MinLevel(level)
-	return s
+func (sub *Sub) MinLevel(level xopconst.Level) *Sub {
+	sub.settings.MinLevel(level)
+	return sub
 }
 
 // MinLevel sets the minimum logging level below which logs will
@@ -124,9 +124,9 @@ func (s *LogSettings) MinLevel(level xopconst.Level) {
 // TagLinesWithSpanSequence controls if the span sequence
 // indicator (see Fork() and Step()) should be included in
 // the prefill data on each line.
-func (s *Sub) TagLinesWithSpanSequence(b bool) *Sub {
-	s.settings.TagLinesWithSpanSequence(b)
-	return s
+func (sub *Sub) TagLinesWithSpanSequence(b bool) *Sub {
+	sub.settings.TagLinesWithSpanSequence(b)
+	return sub
 }
 
 // TagLinesWithSpanSequence controls if the span sequence
@@ -136,18 +136,18 @@ func (s *LogSettings) TagLinesWithSpanSequence(b bool) {
 	s.tagLinesWithSpanSequence = b
 }
 
-func (s *Sub) PrefillText(m string) *Sub {
-	s.settings.PrefillText(m)
-	return s
+func (sub *Sub) PrefillText(m string) *Sub {
+	sub.settings.PrefillText(m)
+	return sub
 }
 
 func (s *LogSettings) PrefillText(m string) {
 	s.prefillMsg = m
 }
 
-func (s *Sub) NoPrefill() *Sub {
-	s.settings.NoPrefill()
-	return s
+func (sub *Sub) NoPrefill() *Sub {
+	sub.settings.NoPrefill()
+	return sub
 }
 
 func (s *LogSettings) NoPrefill() {
@@ -155,19 +155,19 @@ func (s *LogSettings) NoPrefill() {
 	s.prefillMsg = ""
 }
 
-func (l *Log) sendPrefill() {
-	if l.settings.prefillData == nil && l.settings.prefillMsg == "" && !l.settings.tagLinesWithSpanSequence {
-		l.prefilled = l.span.base.NoPrefill()
+func (log *Log) sendPrefill() {
+	if log.settings.prefillData == nil && log.settings.prefillMsg == "" && !log.settings.tagLinesWithSpanSequence {
+		log.prefilled = log.span.base.NoPrefill()
 		return
 	}
-	prefilling := l.span.base.StartPrefill()
-	for _, f := range l.settings.prefillData {
+	prefilling := log.span.base.StartPrefill()
+	for _, f := range log.settings.prefillData {
 		f(prefilling)
 	}
-	if l.settings.tagLinesWithSpanSequence {
-		prefilling.String(xopconst.SpanSequenceCode.Key(), l.span.seed.spanSequenceCode)
+	if log.settings.tagLinesWithSpanSequence {
+		prefilling.String(xopconst.SpanSequenceCode.Key(), log.span.seed.spanSequenceCode)
 	}
-	l.prefilled = prefilling.PrefillComplete(l.settings.prefillMsg)
+	log.prefilled = prefilling.PrefillComplete(log.settings.prefillMsg)
 }
 
 // PrefillAny is used to set a data element that is included on every log
@@ -175,9 +175,9 @@ func (l *Log) sendPrefill() {
 // using https://github.com/mohae/deepcopy 's Copy().
 // PrefillAny is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillAny(k string, v interface{}) *Sub {
-	s.settings.PrefillAny(k, v)
-	return s
+func (sub *Sub) PrefillAny(k string, v interface{}) *Sub {
+	sub.settings.PrefillAny(k, v)
+	return sub
 }
 
 // PrefillAny is used to set a data element that is included on every log
@@ -195,9 +195,9 @@ func (s *LogSettings) PrefillAny(k string, v interface{}) {
 // line.
 // PrefillBool is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillBool(k string, v bool) *Sub {
-	s.settings.PrefillBool(k, v)
-	return s
+func (sub *Sub) PrefillBool(k string, v bool) *Sub {
+	sub.settings.PrefillBool(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillBool(k string, v bool) {
@@ -210,9 +210,9 @@ func (s *LogSettings) PrefillBool(k string, v bool) {
 // line.
 // PrefillDuration is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillDuration(k string, v time.Duration) *Sub {
-	s.settings.PrefillDuration(k, v)
-	return s
+func (sub *Sub) PrefillDuration(k string, v time.Duration) *Sub {
+	sub.settings.PrefillDuration(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillDuration(k string, v time.Duration) {
@@ -225,9 +225,9 @@ func (s *LogSettings) PrefillDuration(k string, v time.Duration) {
 // line.
 // PrefillError is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillError(k string, v error) *Sub {
-	s.settings.PrefillError(k, v)
-	return s
+func (sub *Sub) PrefillError(k string, v error) *Sub {
+	sub.settings.PrefillError(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillError(k string, v error) {
@@ -240,9 +240,9 @@ func (s *LogSettings) PrefillError(k string, v error) {
 // line.
 // PrefillFloat64 is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillFloat64(k string, v float64) *Sub {
-	s.settings.PrefillFloat64(k, v)
-	return s
+func (sub *Sub) PrefillFloat64(k string, v float64) *Sub {
+	sub.settings.PrefillFloat64(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillFloat64(k string, v float64) {
@@ -255,9 +255,9 @@ func (s *LogSettings) PrefillFloat64(k string, v float64) {
 // line.
 // PrefillInt is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillInt(k string, v int64) *Sub {
-	s.settings.PrefillInt(k, v)
-	return s
+func (sub *Sub) PrefillInt(k string, v int64) *Sub {
+	sub.settings.PrefillInt(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillInt(k string, v int64) {
@@ -270,9 +270,9 @@ func (s *LogSettings) PrefillInt(k string, v int64) {
 // line.
 // PrefillLink is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillLink(k string, v trace.Trace) *Sub {
-	s.settings.PrefillLink(k, v)
-	return s
+func (sub *Sub) PrefillLink(k string, v trace.Trace) *Sub {
+	sub.settings.PrefillLink(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillLink(k string, v trace.Trace) {
@@ -285,9 +285,9 @@ func (s *LogSettings) PrefillLink(k string, v trace.Trace) {
 // line.
 // PrefillString is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillString(k string, v string) *Sub {
-	s.settings.PrefillString(k, v)
-	return s
+func (sub *Sub) PrefillString(k string, v string) *Sub {
+	sub.settings.PrefillString(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillString(k string, v string) {
@@ -300,9 +300,9 @@ func (s *LogSettings) PrefillString(k string, v string) {
 // line.
 // PrefillTime is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillTime(k string, v time.Time) *Sub {
-	s.settings.PrefillTime(k, v)
-	return s
+func (sub *Sub) PrefillTime(k string, v time.Time) *Sub {
+	sub.settings.PrefillTime(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillTime(k string, v time.Time) {
@@ -315,9 +315,9 @@ func (s *LogSettings) PrefillTime(k string, v time.Time) {
 // line.
 // PrefillUint is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillUint(k string, v uint64) *Sub {
-	s.settings.PrefillUint(k, v)
-	return s
+func (sub *Sub) PrefillUint(k string, v uint64) *Sub {
+	sub.settings.PrefillUint(k, v)
+	return sub
 }
 
 func (s *LogSettings) PrefillUint(k string, v uint64) {

--- a/sub.zzzgo
+++ b/sub.zzzgo
@@ -42,29 +42,29 @@ func (settings LogSettings) Copy() LogSettings {
 	return settings
 }
 
-func (l *Log) Settings() LogSettings {
-	return l.settings.Copy()
+func (log *Log) Settings() LogSettings {
+	return log.settings.Copy()
 }
 
 // Sub is the first step in creating a sub-Log from the current log.
 // Sub allows log settings to be modified.  The returned value must
 // be used.  It is used by a call to sub.Log(), sub.Fork(), or
 // sub.Step().
-func (l *Log) Sub() *Sub {
+func (log *Log) Sub() *Sub {
 	return &Sub{
-		settings: l.settings.Copy(),
-		log:      l,
+		settings: log.settings.Copy(),
+		log:      log,
 	}
 }
 
 // Fork creates a new Log that does not need to be terminated because
 // it is assumed to be done with the current log is finished.  The new log
 // has its own span.
-func (s *Sub) Fork(msg string, mods ...SeedModifier) *Log {
-	seed := s.log.span.Seed(mods...).SubSpan()
-	counter := int(atomic.AddInt32(&s.log.span.forkCounter, 1))
+func (sub *Sub) Fork(msg string, mods ...SeedModifier) *Log {
+	seed := sub.log.span.Seed(mods...).SubSpan()
+	counter := int(atomic.AddInt32(&sub.log.span.forkCounter, 1))
 	seed.spanSequenceCode += "." + base26(counter-1)
-	return s.log.newChildLog(seed.spanSeed, msg, s.settings)
+	return sub.log.newChildLog(seed.spanSeed, msg, sub.settings)
 }
 
 // Step creates a new log that does not need to be terminated -- it
@@ -72,20 +72,20 @@ func (s *Sub) Fork(msg string, mods ...SeedModifier) *Log {
 // something that is different and should be in a fresh span. The expectation
 // is that there is a parent log that is creating various sub-logs using
 // Step over and over as it does different things.
-func (s *Sub) Step(msg string, mods ...SeedModifier) *Log {
-	seed := s.log.span.Seed(mods...).SubSpan()
-	counter := int(atomic.AddInt32(&s.log.span.stepCounter, 1))
+func (sub *Sub) Step(msg string, mods ...SeedModifier) *Log {
+	seed := sub.log.span.Seed(mods...).SubSpan()
+	counter := int(atomic.AddInt32(&sub.log.span.stepCounter, 1))
 	seed.spanSequenceCode += "." + strconv.Itoa(counter)
-	return s.log.newChildLog(seed.spanSeed, msg, s.settings)
+	return sub.log.newChildLog(seed.spanSeed, msg, sub.settings)
 }
 
 // StackFrames sets the number of stack frames to include at
 // a logging level.  Levels above the given level will be set to
 // get least this many.  Levels below the given level will be set
 // to receive at most this many.
-func (s *Sub) StackFrames(level xopconst.Level, count int) *Sub {
-	s.settings.StackFrames(level, count)
-	return s
+func (sub *Sub) StackFrames(level xopconst.Level, count int) *Sub {
+	sub.settings.StackFrames(level, count)
+	return sub
 }
 
 // StackFrames sets the number of stack frames to include at
@@ -106,9 +106,9 @@ func (s *LogSettings) StackFrames(level xopconst.Level, frameCount int) {
 
 // MinLevel sets the minimum logging level below which logs will
 // be discarded.  The default is that no logs are discarded.
-func (s *Sub) MinLevel(level xopconst.Level) *Sub {
-	s.settings.MinLevel(level)
-	return s
+func (sub *Sub) MinLevel(level xopconst.Level) *Sub {
+	sub.settings.MinLevel(level)
+	return sub
 }
 
 // MinLevel sets the minimum logging level below which logs will
@@ -120,9 +120,9 @@ func (s *LogSettings) MinLevel(level xopconst.Level) {
 // TagLinesWithSpanSequence controls if the span sequence
 // indicator (see Fork() and Step()) should be included in
 // the prefill data on each line.
-func (s *Sub) TagLinesWithSpanSequence(b bool) *Sub {
-	s.settings.TagLinesWithSpanSequence(b)
-	return s
+func (sub *Sub) TagLinesWithSpanSequence(b bool) *Sub {
+	sub.settings.TagLinesWithSpanSequence(b)
+	return sub
 }
 
 // TagLinesWithSpanSequence controls if the span sequence
@@ -132,18 +132,18 @@ func (s *LogSettings) TagLinesWithSpanSequence(b bool) {
 	s.tagLinesWithSpanSequence = b
 }
 
-func (s *Sub) PrefillText(m string) *Sub {
-	s.settings.PrefillText(m)
-	return s
+func (sub *Sub) PrefillText(m string) *Sub {
+	sub.settings.PrefillText(m)
+	return sub
 }
 
 func (s *LogSettings) PrefillText(m string) {
 	s.prefillMsg = m
 }
 
-func (s *Sub) NoPrefill() *Sub {
-	s.settings.NoPrefill()
-	return s
+func (sub *Sub) NoPrefill() *Sub {
+	sub.settings.NoPrefill()
+	return sub
 }
 
 func (s *LogSettings) NoPrefill() {
@@ -151,19 +151,19 @@ func (s *LogSettings) NoPrefill() {
 	s.prefillMsg = ""
 }
 
-func (l *Log) sendPrefill() {
-	if l.settings.prefillData == nil && l.settings.prefillMsg == "" && !l.settings.tagLinesWithSpanSequence {
-		l.prefilled = l.span.base.NoPrefill()
+func (log *Log) sendPrefill() {
+	if log.settings.prefillData == nil && log.settings.prefillMsg == "" && !log.settings.tagLinesWithSpanSequence {
+		log.prefilled = log.span.base.NoPrefill()
 		return
 	}
-	prefilling := l.span.base.StartPrefill()
-	for _, f := range l.settings.prefillData {
+	prefilling := log.span.base.StartPrefill()
+	for _, f := range log.settings.prefillData {
 		f(prefilling)
 	}
-	if l.settings.tagLinesWithSpanSequence {
-		prefilling.String(xopconst.SpanSequenceCode.Key(), l.span.seed.spanSequenceCode)
+	if log.settings.tagLinesWithSpanSequence {
+		prefilling.String(xopconst.SpanSequenceCode.Key(), log.span.seed.spanSequenceCode)
 	}
-	l.prefilled = prefilling.PrefillComplete(l.settings.prefillMsg)
+	log.prefilled = prefilling.PrefillComplete(log.settings.prefillMsg)
 }
 
 // PrefillAny is used to set a data element that is included on every log
@@ -171,9 +171,9 @@ func (l *Log) sendPrefill() {
 // using https://github.com/mohae/deepcopy 's Copy().
 // PrefillAny is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillAny(k string, v interface{}) *Sub {
-	s.settings.PrefillAny(k, v)
-	return s
+func (sub *Sub) PrefillAny(k string, v interface{}) *Sub {
+	sub.settings.PrefillAny(k, v)
+	return sub
 }
 
 // PrefillAny is used to set a data element that is included on every log
@@ -192,9 +192,9 @@ func (s *LogSettings) PrefillAny(k string, v interface{}) {
 // line.
 // PrefillZZZ is not threadsafe with respect to other calls on the same *Sub.
 // Should not be used after Step(), Fork(), or Log() is called.
-func (s *Sub) PrefillZZZ(k string, v zzz) *Sub {
-	s.settings.PrefillZZZ(k, v)
-	return s
+func (sub *Sub) PrefillZZZ(k string, v zzz) *Sub {
+	sub.settings.PrefillZZZ(k, v)
+	return sub
 }
 func (s *LogSettings) PrefillZZZ(k string, v zzz) {
 	s.prefillData = append(s.prefillData, func(line xopbase.Prefilling) {


### PR DESCRIPTION
Addressing the TODO item:
```
Better receiver names

  - change `func (l *Log)` to `func (log *Log)` everywhere
  - change `func (s *Sub)` to `func (sub *Sub)` everywhere
  - change `func (ll *LogLine)` to `func (line *Line)` everywhere
  - change `func (s *Span)` to `func (span *Span)` everywhere
  - change `func (s Seed)` to `func (seed Seed)` everywhere
```