### PR TITLE
Adding more tests in testlogger & renaming receivers.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,36 @@
+package xop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig(t *testing.T) {
+	seed := NewSeed()
+	assert.Equal(t, DefaultConfig.UseB3, seed.config.UseB3)
+	assert.Equal(t, DefaultConfig.FlushDelay, seed.config.FlushDelay)
+
+	seed = NewSeed(WithConfig(DefaultConfig), WithB3(true))
+	assert.Equal(t, true, seed.config.UseB3)
+	assert.Equal(t, DefaultConfig.FlushDelay, seed.config.FlushDelay)
+
+	seed = NewSeed(WithB3(true), WithFlushDelay(time.Second))
+	assert.Equal(t, true, seed.config.UseB3)
+	assert.Equal(t, time.Second, seed.config.FlushDelay)
+}
+
+func TestConfigModifier(t *testing.T) {
+	configModifier := func(cfg *Config) {
+		cfg.UseB3 = true
+	}
+	seed := NewSeed(WithConfigChanges(configModifier))
+	assert.Equal(t, true, seed.config.UseB3)
+}
+
+func TestLogConfig(t *testing.T) {
+	myLog := NewSeed().Request("myLog")
+	assert.Equal(t, DefaultConfig.FlushDelay, myLog.Config().FlushDelay)
+	assert.Equal(t, DefaultConfig.UseB3, myLog.Config().UseB3)
+}

--- a/support_test.go
+++ b/support_test.go
@@ -14,6 +14,7 @@ func TestBase26(t *testing.T) {
 		26: "BA",
 		27: "BB",
 		52: "CA",
+		-1: "-B",
 	}
 	for num, want := range tc {
 		assert.Equalf(t, want, base26(num), "base26(%d)", num)

--- a/xopjson/attributes.go
+++ b/xopjson/attributes.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Writer implements io.Writer interface for json.Encoder
-func (a AttributeBuilder) Write(n []byte) (int, error) {
+func (a *AttributeBuilder) Write(n []byte) (int, error) {
 	*a.encodeTarget = append(*a.encodeTarget, n...)
 	return len(n), nil
 }

--- a/xopjson/attributes.zzzgo
+++ b/xopjson/attributes.zzzgo
@@ -12,7 +12,7 @@ const numSinglePrealloc = 20
 const numMultiPrealloc = 12
 
 // Writer implements io.Writer interface for json.Encoder
-func (a AttributeBuilder) Write(n []byte) (int, error) {
+func (a *AttributeBuilder) Write(n []byte) (int, error) {
 	*a.encodeTarget = append(*a.encodeTarget, n...)
 	return len(n), nil
 }

--- a/xoptest/doc.go
+++ b/xoptest/doc.go
@@ -1,6 +1,6 @@
 /*
 Package xoptest serves two purposes: it is a base logger you can
-use in tests and it is also provides a record of what got logged
+use in tests; it also provides a record of what got logged
 so that tests can introspect their own logs.
 */
 package xoptest

--- a/xoptest/filter.go
+++ b/xoptest/filter.go
@@ -18,12 +18,12 @@ func TextContains(msg string) LinePredicate {
 	}
 }
 
-func (l *TestLogger) FindLines(predicates ...LinePredicate) []*Line {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+func (log *TestLogger) FindLines(predicates ...LinePredicate) []*Line {
+	log.lock.Lock()
+	defer log.lock.Unlock()
 	var found []*Line
 Line:
-	for _, line := range l.Lines {
+	for _, line := range log.Lines {
 		for _, predicate := range predicates {
 			if !predicate(line) {
 				continue Line
@@ -34,6 +34,6 @@ Line:
 	return found
 }
 
-func (l *TestLogger) CountLines(predicates ...LinePredicate) int {
-	return len(l.FindLines(predicates...))
+func (log *TestLogger) CountLines(predicates ...LinePredicate) int {
+	return len(log.FindLines(predicates...))
 }

--- a/xoptest/testlogger.zzzgo
+++ b/xoptest/testlogger.zzzgo
@@ -120,46 +120,46 @@ type Event struct {
 	Msg  string
 }
 
-func (t *TestLogger) Log() *xop.Log {
-	return xop.NewSeed(xop.WithBase(t)).Request(t.t.Name())
+func (log *TestLogger) Log() *xop.Log {
+	return xop.NewSeed(xop.WithBase(log)).Request(log.t.Name())
 }
 
 // WithLock is provided for thread-safe introspection of the logger
-func (l *TestLogger) WithLock(f func(*TestLogger) error) error {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	return f(l)
+func (log *TestLogger) WithLock(f func(*TestLogger) error) error {
+	log.lock.Lock()
+	defer log.lock.Unlock()
+	return f(log)
 }
 
-func (l *TestLogger) CustomEvent(msg string, args ...interface{}) {
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	l.Events = append(l.Events, &Event{
+func (log *TestLogger) CustomEvent(msg string, args ...interface{}) {
+	log.lock.Lock()
+	defer log.lock.Unlock()
+	log.Events = append(log.Events, &Event{
 		Type: CustomEvent,
 		Msg:  fmt.Sprintf(msg, args...),
 	})
 }
 
-func (l *TestLogger) ID() string                   { return l.id }
-func (l *TestLogger) Close()                       {}
-func (l *TestLogger) Buffered() bool               { return false }
-func (l *TestLogger) ReferencesKept() bool         { return true }
-func (l *TestLogger) SetErrorReporter(func(error)) {}
-func (l *TestLogger) Request(ts time.Time, span trace.Bundle, name string) xopbase.Request {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+func (log *TestLogger) ID() string                   { return log.id }
+func (log *TestLogger) Close()                       {}
+func (log *TestLogger) Buffered() bool               { return false }
+func (log *TestLogger) ReferencesKept() bool         { return true }
+func (log *TestLogger) SetErrorReporter(func(error)) {}
+func (log *TestLogger) Request(ts time.Time, span trace.Bundle, name string) xopbase.Request {
+	log.lock.Lock()
+	defer log.lock.Unlock()
 	s := &Span{
-		testLogger:    l,
+		testLogger:    log,
 		IsRequest:     true,
 		Trace:         span,
-		short:         l.setShort(span, name),
+		short:         log.setShort(span, name),
 		StartTime:     ts,
 		Name:          name,
 		Metadata:      make(map[string]interface{}),
 		MetadataTypes: make(map[string]xoputil.BaseAttributeType),
 	}
-	l.Requests = append(l.Requests, s)
-	l.Events = append(l.Events, &Event{
+	log.Requests = append(log.Requests, s)
+	log.Events = append(log.Events, &Event{
 		Type: RequestStart,
 		Span: s,
 	})
@@ -167,93 +167,93 @@ func (l *TestLogger) Request(ts time.Time, span trace.Bundle, name string) xopba
 }
 
 // must hold a lock to call setShort
-func (l *TestLogger) setShort(span trace.Bundle, name string) string {
+func (log *TestLogger) setShort(span trace.Bundle, name string) string {
 	ts := span.Trace.GetTraceID().String()
-	if ti, ok := l.traceMap[ts]; ok {
+	if ti, ok := log.traceMap[ts]; ok {
 		ti.spanCount++
 		ti.spans[span.Trace.GetSpanID().String()] = ti.spanCount
 		short := fmt.Sprintf("T%d.%d", ti.traceNum, ti.spanCount)
-		l.t.Log("Start span " + short + "=" + span.Trace.HeaderString() + " " + name)
+		log.t.Log("Start span " + short + "=" + span.Trace.HeaderString() + " " + name)
 		return short
 	}
-	l.traceCount++
-	l.traceMap[ts] = &traceInfo{
+	log.traceCount++
+	log.traceMap[ts] = &traceInfo{
 		spanCount: 1,
-		traceNum:  l.traceCount,
+		traceNum:  log.traceCount,
 		spans: map[string]int{
 			span.Trace.GetSpanID().String(): 1,
 		},
 	}
-	short := fmt.Sprintf("T%d.%d", l.traceCount, 1)
-	l.t.Log("Start span " + short + "=" + span.Trace.HeaderString() + " " + name)
+	short := fmt.Sprintf("T%d.%d", log.traceCount, 1)
+	log.t.Log("Start span " + short + "=" + span.Trace.HeaderString() + " " + name)
 	return short
 }
 
-func (s *Span) Done(t time.Time) {
-	atomic.StoreInt64(&s.EndTime, t.UnixNano())
-	s.testLogger.lock.Lock()
-	defer s.testLogger.lock.Unlock()
-	if s.IsRequest {
-		s.testLogger.Events = append(s.testLogger.Events, &Event{
+func (span *Span) Done(t time.Time) {
+	atomic.StoreInt64(&span.EndTime, t.UnixNano())
+	span.testLogger.lock.Lock()
+	defer span.testLogger.lock.Unlock()
+	if span.IsRequest {
+		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: RequestDone,
-			Span: s,
+			Span: span,
 		})
 	} else {
-		s.testLogger.Events = append(s.testLogger.Events, &Event{
+		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: SpanDone,
-			Span: s,
+			Span: span,
 		})
 	}
 }
 
-func (s *Span) Flush() {
-	s.testLogger.lock.Lock()
-	defer s.testLogger.lock.Unlock()
-	s.testLogger.Events = append(s.testLogger.Events, &Event{
+func (span *Span) Flush() {
+	span.testLogger.lock.Lock()
+	defer span.testLogger.lock.Unlock()
+	span.testLogger.Events = append(span.testLogger.Events, &Event{
 		Type: FlushEvent,
-		Span: s,
+		Span: span,
 	})
 }
 
-func (s *Span) Boring(bool)                  {}
-func (s *Span) ID() string                   { return s.testLogger.id }
-func (s *Span) SetErrorReporter(func(error)) {}
+func (span *Span) Boring(bool)                  {}
+func (span *Span) ID() string                   { return span.testLogger.id }
+func (span *Span) SetErrorReporter(func(error)) {}
 
-func (s *Span) Span(ts time.Time, span trace.Bundle, name string, spanSequenceCode string) xopbase.Span {
-	s.testLogger.lock.Lock()
-	defer s.testLogger.lock.Unlock()
-	s.lock.Lock()
-	defer s.lock.Unlock()
+func (span *Span) Span(ts time.Time, traceSpan trace.Bundle, name string, spanSequenceCode string) xopbase.Span {
+	span.testLogger.lock.Lock()
+	defer span.testLogger.lock.Unlock()
+	span.lock.Lock()
+	defer span.lock.Unlock()
 	n := &Span{
-		testLogger:    s.testLogger,
-		Trace:         span,
-		short:         s.testLogger.setShort(span, name),
+		testLogger:    span.testLogger,
+		Trace:         traceSpan,
+		short:         span.testLogger.setShort(traceSpan, name),
 		StartTime:     ts,
 		Name:          name,
 		Metadata:      make(map[string]interface{}),
 		MetadataTypes: make(map[string]xoputil.BaseAttributeType),
 		SequenceCode: spanSequenceCode,
 	}
-	s.Spans = append(s.Spans, n)
-	s.testLogger.Spans = append(s.testLogger.Spans, n)
-	s.testLogger.Events = append(s.testLogger.Events, &Event{
+	span.Spans = append(span.Spans, n)
+	span.testLogger.Spans = append(span.testLogger.Spans, n)
+	span.testLogger.Events = append(span.testLogger.Events, &Event{
 		Type: SpanStart,
 		Span: n,
 	})
 	return n
 }
 
-func (s *Span) NoPrefill() xopbase.Prefilled {
+func (span *Span) NoPrefill() xopbase.Prefilled {
 	return &Prefilled{
-		Span: s,
+		Span: span,
 	}
 }
 
-func (s *Span) StartPrefill() xopbase.Prefilling {
+func (span *Span) StartPrefill() xopbase.Prefilling {
 	return &Prefilling{
 		Builder: Builder{
 			Data: make(map[string]interface{}),
-			Span: s,
+			Span: span,
 		},
 	}
 }
@@ -289,57 +289,57 @@ func (p *Prefilled) Line(level xopconst.Level, t time.Time, _ []uintptr) xopbase
 	return line
 }
 
-func (l *Line) Static(m string) {
-	l.Msg(m)
+func (line *Line) Static(m string) {
+	line.Msg(m)
 }
 
-func (l *Line) Msg(m string) {
-	l.Message += m
-	text := l.Span.short + ": " + l.Message
-	if len(l.kvText) > 0 {
-		text += " " + strings.Join(l.kvText, " ")
-		l.kvText = nil
+func (line *Line) Msg(m string) {
+	line.Message += m
+	text := line.Span.short + ": " + line.Message
+	if len(line.kvText) > 0 {
+		text += " " + strings.Join(line.kvText, " ")
+		line.kvText = nil
 	}
-	l.Text = text
-	l.send(text)
+	line.Text = text
+	line.send(text)
 }
 
 var templateRE = regexp.MustCompile(`\{.+?\}`)
 
-func (l *Line) Template(m string) {
-	l.Tmpl = true
-	l.Message += m
+func (line *Line) Template(m string) {
+	line.Tmpl = true
+	line.Message += m
 	used := make(map[string]struct{})
-	text := l.Span.short + ": " +
-		templateRE.ReplaceAllStringFunc(l.Message, func(k string) string {
+	text := line.Span.short + ": " +
+		templateRE.ReplaceAllStringFunc(line.Message, func(k string) string {
 			k = k[1 : len(k)-1]
-			if v, ok := l.Data[k]; ok {
+			if v, ok := line.Data[k]; ok {
 				used[k] = struct{}{}
 				return fmt.Sprint(v)
 			}
 			return "''"
 		})
-	for k, v := range l.Data {
+	for k, v := range line.Data {
 		if _, ok := used[k]; !ok {
 			text += " " + k + "=" + fmt.Sprint(v)
 		}
 	}
-	l.Text = text
-	l.send(text)
+	line.Text = text
+	line.send(text)
 }
 
-func (l Line) send(text string) {
-	l.Span.testLogger.t.Log(text)
-	l.Span.testLogger.lock.Lock()
-	defer l.Span.testLogger.lock.Unlock()
-	l.Span.lock.Lock()
-	defer l.Span.lock.Unlock()
-	l.Span.testLogger.Lines = append(l.Span.testLogger.Lines, &l)
-	l.Span.testLogger.Events = append(l.Span.testLogger.Events, &Event{
+func (line Line) send(text string) {
+	line.Span.testLogger.t.Log(text)
+	line.Span.testLogger.lock.Lock()
+	defer line.Span.testLogger.lock.Unlock()
+	line.Span.lock.Lock()
+	defer line.Span.lock.Unlock()
+	line.Span.testLogger.Lines = append(line.Span.testLogger.Lines, &line)
+	line.Span.testLogger.Events = append(line.Span.testLogger.Events, &Event{
 		Type: LineEvent,
-		Line: &l,
+		Line: &line,
 	})
-	l.Span.Lines = append(l.Span.Lines, &l)
+	line.Span.Lines = append(line.Span.Lines, &line)
 }
 
 func (b *Builder) Any(k string, v interface{}) {

--- a/xoptest/testlogger_test.go
+++ b/xoptest/testlogger_test.go
@@ -1,27 +1,28 @@
 package xoptest_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/muir/xop-go/xopconst"
 	"github.com/muir/xop-go/xoptest"
 	"github.com/muir/xop-go/xoputil"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLogMethods(t *testing.T) {
 	start := time.Now()
-	tlog := xoptest.New(t)
-	log := tlog.Log()
+	tLog := xoptest.New(t)
+	defer tLog.Close()
+	log := tLog.Log()
 	log.Info().Msg("basic info message")
 	log.Error().Msg("basic error message")
 	log.Alert().Msg("basic alert message")
 	log.Debug().Msg("basic debug message")
 	log.Trace().Msg("basic trace message")
 	log.Info().String("foo", "bar").Int("num", 38).Template("a test {foo} with {num}")
-	lines := tlog.FindLines(xoptest.MessageEquals("basic trace message"))
+	lines := tLog.FindLines(xoptest.MessageEquals("basic trace message"))
 	if assert.NotEmpty(t, lines, "found some") {
 		assert.True(t, !lines[0].Timestamp.Before(start), "time seq")
 		assert.Equal(t, "basic trace message", lines[0].Message, "message")
@@ -29,14 +30,57 @@ func TestLogMethods(t *testing.T) {
 	}
 	f := log.Sub().Fork("forkie")
 	f.Span().Int(xopconst.HTTPStatusCode, 204)
-	assert.Empty(t, tlog.FindLines(xoptest.MessageEquals("basic debug message")), "debug filtered out by log level")
-	assert.Equal(t, 1, tlog.CountLines(xoptest.MessageEquals("basic alert message")), "count alert")
-	assert.Equal(t, 1, tlog.CountLines(xoptest.TextContains("a test")), "count a test")
-	assert.Equal(t, 1, tlog.CountLines(xoptest.TextContains("a test bar")), "count a test foo")
-	assert.Equal(t, 1, tlog.CountLines(xoptest.TextContains("a test bar with 38")), "count a test foo with 38")
-	if assert.NotEmpty(t, tlog.Spans, "have a sub-span") {
-		assert.Equal(t, ".A", tlog.Spans[0].SequenceCode, "span sequence for fork")
-		assert.Equal(t, int64(204), tlog.Spans[0].Metadata["http.status_code"], "an explicit attribute")
-		assert.Equal(t, xoputil.BaseAttributeTypeInt64, tlog.Spans[0].MetadataTypes["http.status_code"], "http status code attribute type")
+	assert.Empty(t, tLog.FindLines(xoptest.MessageEquals("basic debug message")), "debug filtered out by log level")
+	assert.Equal(t, 1, tLog.CountLines(xoptest.MessageEquals("basic alert message")), "count alert")
+	assert.Equal(t, 1, tLog.CountLines(xoptest.TextContains("a test")), "count a test")
+	assert.Equal(t, 1, tLog.CountLines(xoptest.TextContains("a test bar")), "count a test foo")
+	assert.Equal(t, 1, tLog.CountLines(xoptest.TextContains("a test bar with 38")), "count a test foo with 38")
+	if assert.NotEmpty(t, tLog.Spans, "have a sub-span") {
+		assert.Equal(t, ".A", tLog.Spans[0].SequenceCode, "span sequence for fork")
+		assert.Equal(t, int64(204), tLog.Spans[0].Metadata["http.status_code"], "an explicit attribute")
+		assert.Equal(t, xoputil.BaseAttributeTypeInt64, tLog.Spans[0].MetadataTypes["http.status_code"], "http status code attribute type")
 	}
+}
+
+func TestWithLock(t *testing.T) {
+	var err1 error
+	var err2 error
+	message := make(chan int, 2)
+	defer close(message)
+	wg := sync.WaitGroup{}
+	invocations := 0
+	f := func(l *xoptest.TestLogger) error {
+		defer wg.Done()
+		time.Sleep(100 * time.Millisecond)
+		invocations++
+		message <- invocations
+		return nil
+	}
+	tLog := xoptest.New(t)
+	defer tLog.Close()
+	wg.Add(1)
+	go func() {
+		err1 = tLog.WithLock(f)
+	}()
+	wg.Add(1)
+	go func() {
+		err2 = tLog.WithLock(f)
+	}()
+
+	wg.Wait()
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.Equal(t, 1, <-message)
+	assert.Equal(t, 2, <-message)
+}
+
+func TestCustomEvent(t *testing.T) {
+	tLog := xoptest.New(t)
+	defer tLog.Close()
+	f := func(_ error) {}
+	tLog.SetErrorReporter(f)
+	tLog.CustomEvent("custom message (%v-%v)", "foo", "bar")
+	assert.Len(t, tLog.Events, 1)
+	assert.Equal(t, "custom message (foo-bar)", tLog.Events[0].Msg)
+	assert.Equal(t, xoptest.CustomEvent, tLog.Events[0].Type)
 }

--- a/xoptest/testlogger_test.go
+++ b/xoptest/testlogger_test.go
@@ -55,13 +55,12 @@ func TestWithLock(t *testing.T) {
 	}
 	tLog := xoptest.New(t)
 	defer tLog.Close()
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		err := tLog.WithLock(f)
 		assert.NoError(t, err)
 	}()
-	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		err := tLog.WithLock(f)


### PR DESCRIPTION
I have renamed the receivers in `testlogger.zzzgo` file. I have added more tests to cover the missing methods for `testlogger`. I have completed 100% coverage for `support.go` file... Still I am wrapping my head on how to test only the methods for `seed.go`, `span.go` and `config.go`.