### PR TITLE
Fifty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ golanglint:
 lint:;
 	golangci-lint run
 	
+misspell:;
+	go install github.com/client9/misspell/cmd/misspell@latest
+	misspell -error `find . -name \*.md`

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,16 @@ lint:;
 	
 misspell:;
 	go install github.com/client9/misspell/cmd/misspell@latest
-	misspell -error `find . -name \*.md`
+	misspell -w `find . -name \*.md`
+
+OTEL_TAG="v1.12.0"
+
+../opentelemetry-specification:
+	cd ..; git clone https://github.com/open-telemetry/opentelemetry-specification.git
+
+../opentelemetry-go:
+	cd ..; git clone https://github.com/open-telemetry/opentelemetry-go.git
+
+otel-generate: ../opentelemetry-specification ../opentelemetry-go
+	cd ../opentelemetry-specification && git pull && git checkout tags/$(OTEL_TAG)
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ standard for what log fields mean.  The closest for this is the naming semantics
 that are included in the Open Telementry project.
 
 Once the logs are generated, good logging systems tag each line with trance and
-span identifiers, but the logs are still stored, searched, and dispalyed as
+span identifiers, but the logs are still stored, searched, and displayed as
 lines.  Most of the value comes from the context of the log so recording them
 as lines removes misses the point.
 
@@ -130,7 +130,7 @@ Should this be enforced?  XXX how?
 
 Spans have a text description
 
-Spans have arbitray key/value pairs that are added as users create
+Spans have arbitrary key/value pairs that are added as users create
 the span.
 
 Spans have a W3C-compatible id
@@ -151,7 +151,7 @@ Log lines can have key/value pairs
 
 If the key is "span" then the value should be full span reference
 
-The key of "type" should be displayed prominately by the front-end and
+The key of "type" should be displayed prominently by the front-end and
 the following types are suggested:
 
 - "reference": requires a "span" and referes to that span
@@ -262,7 +262,7 @@ to the individual base loggers.
 The data associated with spans, traces, and requests must come from pre-registered
 keys.
 
-# Philosphy
+# Philosophy
 
 Xop is opinionated.  It gently nudges in certain directions.  Perhaps
 the biggest nudge is that there is no support for generating

--- a/TODO.md
+++ b/TODO.md
@@ -144,7 +144,7 @@
 - Performmance
 
   - mark all places in the code where an allocation happens `// allocate`
-  - Use sync.Pool agressively to reduce allocations
+  - Use sync.Pool aggressively to reduce allocations
 
     - xop.Logger
 
@@ -159,7 +159,7 @@
 
      Rebuild https://github.com/Workiva/go-datastructures/blob/master/queue/ring.go to be
      "LossyPool" that queues upto 32 items (tossing any extra) and returning immedately if
-     there aren't any availble.  Use generics so no casting is needed.
+     there aren't any available.  Use generics so no casting is needed.
 
   - AttributeBuilder needs a JSON-specific version
 
@@ -167,7 +167,7 @@
     - 64 buffers?
     - 64 bytes each?
 
-  - how to make protobuf faster (when building OTEL compatability):
+  - how to make protobuf faster (when building OTEL compatibility):
     [notes](https://blog.najaryan.net/posts/partial-protobuf-encoding/?s=09)
 
   - can *Sub be Sub instead?  Would that have better performance? 

--- a/basegroup.go
+++ b/basegroup.go
@@ -102,9 +102,9 @@ func (s baseSpans) Span(t time.Time, span trace.Bundle, descriptionOrName string
 	return baseSpans
 }
 
-func (s baseSpans) Done(t time.Time) {
+func (s baseSpans) Done(t time.Time, final bool) {
 	for _, span := range s {
-		span.Done(t)
+		span.Done(t, final)
 	}
 }
 

--- a/basegroup.zzzgo
+++ b/basegroup.zzzgo
@@ -94,9 +94,9 @@ func (s baseSpans) Span(t time.Time, span trace.Bundle, descriptionOrName string
 	return baseSpans
 }
 
-func (s baseSpans) Done(t time.Time) {
+func (s baseSpans) Done(t time.Time, final bool) {
 	for _, span := range s {
-		span.Done(t)
+		span.Done(t, final)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -320,10 +320,10 @@ func (log *Log) recursiveDone(done bool, now time.Time) (count int32) {
 	if done {
 		atomic.StoreInt32(&log.span.knownActive, 0)
 		count = atomic.AddInt32(&log.span.doneCount, 1)
-		log.span.base.Done(time.Now())
+		log.span.base.Done(time.Now(), true)
 	} else {
 		if atomic.SwapInt32(&log.span.knownActive, 0) == 1 {
-			log.span.base.Done(now)
+			log.span.base.Done(now, false)
 		}
 	}
 	deps := func() []*Log {

--- a/xopbase/base.go
+++ b/xopbase/base.go
@@ -93,7 +93,16 @@ type Span interface {
 	// corresponding to this span, and the log is not Detach()ed; or
 	// (3) preceeding Flush() if there has been logging activity since the
 	// last call to Flush(), Done(), or the start of the span.
-	Done(time.Time)
+	//
+	// final is true when the log is done, it is false when Done is called
+	// prior to a Flush().  Just because Done was called with final does not
+	// mean that Done won't be called again.  Any further calls would only
+	// happen due a bug in the application: logging things after calling
+	// log.Done.
+	//
+	// If the application never calls log.Done(), then final will never
+	// be true.
+	Done(endTime time.Time, final bool)
 }
 
 type Prefilling interface {

--- a/xopbase/base.zzzgo
+++ b/xopbase/base.zzzgo
@@ -78,7 +78,16 @@ type Span interface {
 	// corresponding to this span, and the log is not Detach()ed; or
 	// (3) preceeding Flush() if there has been logging activity since the
 	// last call to Flush(), Done(), or the start of the span.
-	Done(time.Time)
+	//
+	// final is true when the log is done, it is false when Done is called
+	// prior to a Flush().  Just because Done was called with final does not
+	// mean that Done won't be called again.  Any further calls would only 
+	// happen due a bug in the application: logging things after calling
+	// log.Done.
+	//
+	// If the application never calls log.Done(), then final will never
+	// be true.
+	Done(endTime time.Time, final bool)
 }
 
 type Prefilling interface {

--- a/xopjson/jsonlogger.go
+++ b/xopjson/jsonlogger.go
@@ -323,7 +323,7 @@ func (s *span) FlushAttributes() {
 	}
 }
 
-func (s *span) Done(t time.Time) {
+func (s *span) Done(t time.Time, _ bool) {
 	atomic.StoreInt64(&s.endTime, t.UnixNano())
 	s.FlushAttributes()
 }

--- a/xopjson/jsonlogger.zzzgo
+++ b/xopjson/jsonlogger.zzzgo
@@ -321,7 +321,7 @@ func (s *span) FlushAttributes() {
 	}
 }
 
-func (s *span) Done(t time.Time) {
+func (s *span) Done(t time.Time, _ bool) {
 	atomic.StoreInt64(&s.endTime, t.UnixNano())
 	s.FlushAttributes()
 }

--- a/xopnum/levels.go
+++ b/xopnum/levels.go
@@ -1,9 +1,5 @@
 package xopnum
 
-import (
-	"sync/atomic"
-)
-
 //go:generate enumer -type=Level -linecomment -json -sql
 
 type Level int32

--- a/xopnum/levels.go
+++ b/xopnum/levels.go
@@ -23,11 +23,3 @@ const (
 )
 
 const MaxLevel = AlertLevel
-
-func (level *Level) AtomicLoad() Level {
-	return Level(atomic.LoadInt32((*int32)(level)))
-}
-
-func (level *Level) AtomicStore(newLevel Level) {
-	atomic.StoreInt32((*int32)(level), int32(newLevel))
-}

--- a/xoptest/testlogger.go
+++ b/xoptest/testlogger.go
@@ -126,6 +126,7 @@ type Event struct {
 	Line *Line
 	Span *Span
 	Msg  string
+	Done bool
 }
 
 func (log *TestLogger) Log() *xop.Log {
@@ -198,7 +199,7 @@ func (log *TestLogger) setShort(span trace.Bundle, name string) string {
 	return short
 }
 
-func (span *Span) Done(t time.Time) {
+func (span *Span) Done(t time.Time, final bool) {
 	atomic.StoreInt64(&span.EndTime, t.UnixNano())
 	span.testLogger.lock.Lock()
 	defer span.testLogger.lock.Unlock()
@@ -206,11 +207,13 @@ func (span *Span) Done(t time.Time) {
 		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: RequestDone,
 			Span: span,
+			Done: final,
 		})
 	} else {
 		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: SpanDone,
 			Span: span,
+			Done: final,
 		})
 	}
 }

--- a/xoptest/testlogger.zzzgo
+++ b/xoptest/testlogger.zzzgo
@@ -122,6 +122,7 @@ type Event struct {
 	Line *Line
 	Span *Span
 	Msg  string
+	Done	bool
 }
 
 func (log *TestLogger) Log() *xop.Log {
@@ -194,7 +195,7 @@ func (log *TestLogger) setShort(span trace.Bundle, name string) string {
 	return short
 }
 
-func (span *Span) Done(t time.Time) {
+func (span *Span) Done(t time.Time, final bool) {
 	atomic.StoreInt64(&span.EndTime, t.UnixNano())
 	span.testLogger.lock.Lock()
 	defer span.testLogger.lock.Unlock()
@@ -202,11 +203,13 @@ func (span *Span) Done(t time.Time) {
 		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: RequestDone,
 			Span: span,
+			Done: final,
 		})
 	} else {
 		span.testLogger.Events = append(span.testLogger.Events, &Event{
 			Type: SpanDone,
 			Span: span,
+			Done: final,
 		})
 	}
 }

--- a/xoptest/xoptestutil/timestamp.go
+++ b/xoptest/xoptestutil/timestamp.go
@@ -53,12 +53,13 @@ var formats = []struct {
 	{
 		fmt: time.ANSIC,
 		// Sun Sep  4 22:08:53 2022
-		re: regexp.MustCompile(`^(?:Mon|Tue|Wed|Thr|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: \d|\d\d) \d\d:\d\d:\d\d \d\d\d\d$`),
+		// Thu Sep  8 04:19:52 2022
+		re: regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: \d|\d\d) \d\d:\d\d:\d\d \d\d\d\d$`),
 	},
 	{
 		// Sun Sep  4 22:13:15 PDT 2022
 		fmt: time.UnixDate,
-		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thr|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: \d|\d\d) \d\d:\d\d:\d\d [A-Z]{2,5} \d\d\d\d$`),
+		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: \d|\d\d) \d\d:\d\d:\d\d [A-Z]{2,5} \d\d\d\d$`),
 	},
 	{
 		fmt: time.RubyDate,
@@ -78,11 +79,11 @@ var formats = []struct {
 	},
 	{
 		fmt: time.RFC1123,
-		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thr|Fri|Sat|Sun), \d\d (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d\d\d \d\d:\d\d:\d\d [A-Z]{2,5}$`),
+		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d\d (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d\d\d \d\d:\d\d:\d\d [A-Z]{2,5}$`),
 	},
 	{
 		fmt: time.RFC1123Z,
-		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thr|Fri|Sat|Sun), \d\d (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d\d\d \d\d:\d\d:\d\d [-+]\d\d\d\d$`),
+		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d\d (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d\d\d \d\d:\d\d:\d\d [-+]\d\d\d\d$`),
 	},
 }
 

--- a/xoptest/xoptestutil/timestamp.go
+++ b/xoptest/xoptestutil/timestamp.go
@@ -62,8 +62,9 @@ var formats = []struct {
 		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: \d|\d\d) \d\d:\d\d:\d\d [A-Z]{2,5} \d\d\d\d$`),
 	},
 	{
+		// Thu Sep 08 04:21:27 +0000 2022
 		fmt: time.RubyDate,
-		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thr|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d? \d\d:\d\d:\d\d [-+]\d\d\d\d \d\d\d\d$`),
+		re:  regexp.MustCompile(`^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d\d? \d\d:\d\d:\d\d [-+]\d\d\d\d \d\d\d\d$`),
 	},
 	{
 		fmt: time.RFC822,

--- a/xoptest/xoptestutil/timestamp_test.go
+++ b/xoptest/xoptestutil/timestamp_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestDecode(t *testing.T) {
 	cases := []struct {
+		name       string
 		timeFormat string
 		divide     time.Duration
 		gmt        bool
@@ -35,37 +36,45 @@ func TestDecode(t *testing.T) {
 			rounding: time.Second,
 		},
 		{
+			name:       "rfc3339 GMT",
 			timeFormat: time.RFC3339,
 			rounding:   time.Second,
 			gmt:        true,
 		},
 		{
+			name:       "rfc3339",
 			timeFormat: time.RFC3339,
 			rounding:   time.Second,
 		},
 		{
+			name:       "rfc3339 nano",
 			timeFormat: time.RFC3339Nano,
 			rounding:   time.Microsecond,
 		},
 		{
+			name:       "rfc3339 nano gmt",
 			timeFormat: time.RFC3339Nano,
 			rounding:   time.Microsecond,
 			gmt:        true,
 		},
 		{
+			name:       "ansic",
 			timeFormat: time.ANSIC,
 			gmt:        true,
 			rounding:   time.Second,
 		},
 		{
+			name:       "unixdate",
 			timeFormat: time.UnixDate,
 			rounding:   time.Second,
 		},
 		{
+			name:       "rubydate",
 			timeFormat: time.RubyDate,
 			rounding:   time.Second,
 		},
 		{
+			name:       "rfc822",
 			timeFormat: time.RFC822,
 			gmt:        true,
 			rounding:   time.Minute,
@@ -74,7 +83,10 @@ func TestDecode(t *testing.T) {
 
 	for _, tc := range cases {
 		tc := tc
-		name := tc.timeFormat
+		name := tc.name
+		if name == "" {
+			name = tc.timeFormat
+		}
 		if name == "" {
 			name = tc.divide.String()
 		}


### PR DESCRIPTION
[add misspell](https://github.com/muir/xop-go/commit/9abdf5aac23a4e04aea4ee5e399964b1a8d4630b)

[start looking at OTEL semconv](https://github.com/muir/xop-go/commit/a9bfb4aeba77172ca01ad66a970331361861a4d5)

[level is no longer a global and doesn't need atomic ops](https://github.com/muir/xop-go/commit/0b3980e83c70241164d282553f6cd42d5653837c)

[add "final" parameter to Done(); bugfix time parsing](https://github.com/muir/xop-go/commit/4237c46cf4dbc99136e42c58211e9c6b8d78b17f)